### PR TITLE
Add HTML render script for completion JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This repository contains a sample response from the OpenAI Chat Completion API.
 The file `completion.json` is the unmodified JSON that was returned by GPT-4
-when asked a simple question. The empty `completion.html` file is a placeholder
-for any future HTML that might render or visualize this data.
+when asked a simple question. Use `render_completion.py` to generate a
+`completion.html` file with a formatted view of this data.
 
 ## Source of the JSON
 
@@ -50,4 +50,16 @@ Hi! How can I help you today?
 
 This repository is primarily a simple example of what a Chat Completion API
 response looks like and how you might parse it in scripts or other tools.
+
+### Render HTML
+
+The repository now includes `render_completion.py`, a small script that reads
+`completion.json` and generates an HTML view. Running the script will create or
+overwrite `completion.html` with a table of each token and its log probability:
+
+```bash
+python3 render_completion.py
+```
+
+Open `completion.html` in your browser to see the formatted output.
 

--- a/completion.html
+++ b/completion.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='utf-8'>
+<title>Completion Response</title>
+<style>
+body { font-family: Arial, sans-serif; }
+table { border-collapse: collapse; }
+th, td { border: 1px solid #999; padding: 4px 8px; }
+</style>
+</head>
+<body>
+<h1>Model: gpt-4.1-2025-04-14</h1>
+<p><strong>Created:</strong> 1752327963</p>
+<p>Hi! How can I help you today?</p>
+<h2>Token Logprobs</h2>
+<table>
+<tr><th>Token</th><th>Logprob</th></tr>
+<tr><td>Hi</td><td>-1.314341425895691</td></tr>
+<tr><td>!</td><td>-0.061997607350349426</td></tr>
+<tr><td> How</td><td>-0.029911896213889122</td></tr>
+<tr><td> can</td><td>-0.00023059594968799502</td></tr>
+<tr><td> I</td><td>0.0</td></tr>
+<tr><td> help</td><td>-0.4740796685218811</td></tr>
+<tr><td> you</td><td>-2.816093228830141e-06</td></tr>
+<tr><td> today</td><td>-4.5491004129871726e-05</td></tr>
+<tr><td>?</td><td>-3.173704271830502e-06</td></tr>
+</table>
+</body>
+</html>

--- a/render_completion.py
+++ b/render_completion.py
@@ -1,0 +1,44 @@
+import json
+import html
+
+with open('completion.json', 'r', encoding='utf-8') as f:
+    data = json.load(f)
+
+model = data.get('model', '')
+created = data.get('created')
+message = data['choices'][0]['message']['content']
+tokens = data['choices'][0].get('logprobs', {}).get('content', [])
+
+rows = []
+for entry in tokens:
+    token = entry.get('token', '')
+    logprob = entry.get('logprob')
+    rows.append(f"<tr><td>{html.escape(token)}</td><td>{logprob}</td></tr>")
+rows_html = "\n".join(rows)
+
+html_output = f"""<!DOCTYPE html>
+<html lang='en'>
+<head>
+<meta charset='utf-8'>
+<title>Completion Response</title>
+<style>
+body {{ font-family: Arial, sans-serif; }}
+table {{ border-collapse: collapse; }}
+th, td {{ border: 1px solid #999; padding: 4px 8px; }}
+</style>
+</head>
+<body>
+<h1>Model: {html.escape(model)}</h1>
+<p><strong>Created:</strong> {created}</p>
+<p>{html.escape(message)}</p>
+<h2>Token Logprobs</h2>
+<table>
+<tr><th>Token</th><th>Logprob</th></tr>
+{rows_html}
+</table>
+</body>
+</html>"""
+
+with open('completion.html', 'w', encoding='utf-8') as f:
+    f.write(html_output)
+print('Wrote completion.html')


### PR DESCRIPTION
## Summary
- add `render_completion.py` script to create an HTML view of the JSON
- generate sample `completion.html`
- update `README` with instructions

## Testing
- `python3 render_completion.py`

------
https://chatgpt.com/codex/tasks/task_e_6878acf3dccc832a8852d80a0c21054c